### PR TITLE
Add support for overriding config options via system properties

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
@@ -49,9 +49,9 @@ class SpockReportExtension implements IGlobalExtension {
 		println "Configuring ${this.class.name}"
 		def config = configLoader.loadConfig()
 		reportCreatorClassName = config.getProperty( IReportCreator.class.name )
-		outputDir = config.getProperty( "com.athaydes.spockframework.report.outputDir" )
+		outputDir = config.getProperty( ConfigLoader.PROP_OUTPUT_DIR )
 		hideEmptyBlocks = Boolean.parseBoolean(
-				config.getProperty( "com.athaydes.spockframework.report.hideEmptyBlocks" )
+				config.getProperty( ConfigLoader.PROP_HIDE_EMPTY_BLOCKS )
 		)
 
 		try {

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/ConfigLoader.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/ConfigLoader.groovy
@@ -1,18 +1,27 @@
 package com.athaydes.spockframework.report.internal
 
-import com.athaydes.spockframework.report.IReportCreator
 import org.spockframework.runtime.RunContext
+
+import com.athaydes.spockframework.report.IReportCreator
 
 /**
  *
  * User: Renato
  */
 class ConfigLoader {
+	static final PROP_OUTPUT_DIR = 'com.athaydes.spockframework.report.outputDir'
+	static final PROP_HIDE_EMPTY_BLOCKS = 'com.athaydes.spockframework.report.hideEmptyBlocks'
 
 	final CUSTOM_CONFIG = "META-INF/services/${IReportCreator.class.name}.properties"
-
+	
 	Properties loadConfig( ) {
-		loadCustomProperties( loadDefaultProperties() )
+		def props = loadCustomProperties( loadDefaultProperties() )
+		[IReportCreator.class.name, PROP_OUTPUT_DIR, PROP_HIDE_EMPTY_BLOCKS].each {
+			def sysVal = System.properties[it]
+			if(sysVal)
+				props[it] = sysVal
+		}
+		props
 	}
 
 	Properties loadDefaultProperties( ) {

--- a/src/test/groovy/com/athaydes/spockframework/report/internal/ConfigLoaderSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/internal/ConfigLoaderSpec.groovy
@@ -1,6 +1,7 @@
 package com.athaydes.spockframework.report.internal
 
 import com.athaydes.spockframework.report.IReportCreator
+
 import spock.lang.Specification
 
 /**
@@ -59,6 +60,38 @@ class ConfigLoaderSpec extends Specification {
 
 		where:
 		expected << [ 'example/report.css' ]
+	}
+	
+	def 'System properties should override props files'() {
+		given:
+		"A ConfigLoader without any custom configuration"
+		def configLoader = new ConfigLoader()
+
+		and:
+		"The configLocation exists"
+		( configLoader.CUSTOM_CONFIG as File ).exists()
+		
+		and:
+		"I have specified a system property override"
+		def origPropVal = System.properties[ConfigLoader.PROP_HIDE_EMPTY_BLOCKS]
+		System.properties[ConfigLoader.PROP_HIDE_EMPTY_BLOCKS] = expected
+
+		when:
+		"I ask the ConfigLoader to load the configuration"
+		def result = configLoader.loadConfig()
+		
+		then:
+		"The ConfigLoader must use the value from the system property override"
+		result.getProperty( ConfigLoader.PROP_HIDE_EMPTY_BLOCKS ) == expected
+		
+		cleanup:
+		if(origPropVal)
+			System.properties[ConfigLoader.PROP_HIDE_EMPTY_BLOCKS] = origPropVal
+		else
+			System.properties.remove ConfigLoader.PROP_HIDE_EMPTY_BLOCKS 
+			
+		where:
+		expected = 'custom_value'
 	}
 
 	private createFileUnderMetaInf( String fileName ) {


### PR DESCRIPTION
To make the extension a little more friendly for command line based apps
that want to generate spock reports as part of an application, these
changes allow the key config options to be overridden by system
properties.  When specified, the system properties take precedence.