### PR TITLE
Convert extension logging from println()s to @Log

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
@@ -1,9 +1,9 @@
 package com.athaydes.spockframework.report
 
-import com.athaydes.spockframework.report.internal.ConfigLoader
-import com.athaydes.spockframework.report.internal.FeatureRun
-import com.athaydes.spockframework.report.internal.SpecData
-import com.athaydes.spockframework.report.internal.SpecProblem
+import groovy.util.logging.Log
+
+import java.util.logging.Level
+
 import org.spockframework.runtime.IRunListener
 import org.spockframework.runtime.extension.IGlobalExtension
 import org.spockframework.runtime.model.ErrorInfo
@@ -11,10 +11,16 @@ import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.IterationInfo
 import org.spockframework.runtime.model.SpecInfo
 
+import com.athaydes.spockframework.report.internal.ConfigLoader
+import com.athaydes.spockframework.report.internal.FeatureRun
+import com.athaydes.spockframework.report.internal.SpecData
+import com.athaydes.spockframework.report.internal.SpecProblem
+
 /**
  *
  * User: Renato
  */
+@Log
 class SpockReportExtension implements IGlobalExtension {
 
 	static final PROJECT_URL = 'https://github.com/renatoathaydes/spock-reports'
@@ -40,13 +46,12 @@ class SpockReportExtension implements IGlobalExtension {
 				specInfo.addListener new SpecInfoListener( reportCreator )
 
 			} catch ( e ) {
-				e.printStackTrace()
-				println "Failed to create instance of $reportCreatorClassName: $e"
+				log.log(Level.FINE, "Failed to create instance of $reportCreatorClassName", e)
 			}
 	}
 
 	void config() {
-		println "Configuring ${this.class.name}"
+		log.finer "Configuring ${this.class.name}"
 		def config = configLoader.loadConfig()
 		reportCreatorClassName = config.getProperty( IReportCreator.class.name )
 		outputDir = config.getProperty( "com.athaydes.spockframework.report.outputDir" )
@@ -57,8 +62,7 @@ class SpockReportExtension implements IGlobalExtension {
 		try {
 			reportCreatorSettings << loadSettingsFor( reportCreatorClassName, config )
 		} catch ( e ) {
-			e.printStackTrace()
-			println "Error configuring ${this.class.name}! $e"
+			log.log(Level.FINE, "Error configuring ${this.class.name}!", e)
 		}
 	}
 

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/AbstractHtmlCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/AbstractHtmlCreator.groovy
@@ -1,12 +1,17 @@
 package com.athaydes.spockframework.report.internal
 
-import com.athaydes.spockframework.report.SpockReportExtension
+import groovy.util.logging.Log
 import groovy.xml.MarkupBuilder
+
+import java.util.logging.Level
+
+import com.athaydes.spockframework.report.SpockReportExtension
 
 /**
  *
  * User: Renato
  */
+@Log
 abstract class AbstractHtmlCreator<T> {
 
 	String css
@@ -21,10 +26,10 @@ abstract class AbstractHtmlCreator<T> {
 			try {
 				this.@css = cssResource.text
 			} catch ( e ) {
-				println "${this.class.name}: Failed to set CSS file to $css: $e"
+				log.log(Level.FINE, "${this.class.name}: Failed to set CSS file to $css", e)
 			}
 		else
-			println "${this.class.name}: The CSS file does not exist: ${css}"
+			log.fine "${this.class.name}: The CSS file does not exist: ${css}"
 	}
 
 	File createReportsDir( ) {

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/ConfigLoader.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/ConfigLoader.groovy
@@ -1,12 +1,18 @@
 package com.athaydes.spockframework.report.internal
 
-import com.athaydes.spockframework.report.IReportCreator
+import groovy.util.logging.Log
+
+import java.util.logging.Level
+
 import org.spockframework.runtime.RunContext
+
+import com.athaydes.spockframework.report.IReportCreator
 
 /**
  *
  * User: Renato
  */
+@Log
 class ConfigLoader {
 
 	final CUSTOM_CONFIG = "META-INF/services/${IReportCreator.class.name}.properties"
@@ -29,7 +35,7 @@ class ConfigLoader {
 			try {
 				url.withInputStream { properties.load it }
 			} catch ( IOException | IllegalArgumentException e ) {
-				println "Unable to read config from ${url.path}, $e"
+				log.log(Level.FINE, "Unable to read config from ${url.path}", e)
 			}
 		}
 		properties

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregator.groovy
@@ -1,12 +1,16 @@
 package com.athaydes.spockframework.report.internal
 
+import groovy.util.logging.Log
 import groovy.xml.MarkupBuilder
+
+import java.util.logging.Level
 
 /**
  *
  * User: Renato
  */
 @Singleton( lazy = true )
+@Log
 class HtmlReportAggregator extends AbstractHtmlCreator<Map> {
 
 	final Map<String, Map> aggregatedData = [ : ]
@@ -26,12 +30,11 @@ class HtmlReportAggregator extends AbstractHtmlCreator<Map> {
 				new File( reportsDir, 'index.html' )
 						.write( reportFor( stats ) )
 			} catch ( e ) {
-				e.printStackTrace()
-				println "${this.class.name} failed to create aggregated report, Reason: $e"
+				log.log(Level.FINE, "${this.class.name} failed to create aggregated report", e)
 			}
 
 		} else {
-			println "${this.class.name} cannot create output directory: ${reportsDir.absolutePath}"
+			log.fine "${this.class.name} cannot create output directory: ${reportsDir.absolutePath}"
 		}
 	}
 

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -1,20 +1,26 @@
 package com.athaydes.spockframework.report.internal
 
-import com.athaydes.spockframework.report.IReportCreator
-import groovy.xml.MarkupBuilder
-import org.spockframework.runtime.model.BlockInfo
-import org.spockframework.runtime.model.FeatureInfo
-import org.spockframework.runtime.model.IterationInfo
-import spock.lang.Unroll
-
 import static com.athaydes.spockframework.report.internal.FailureKind.ERROR
 import static com.athaydes.spockframework.report.internal.FailureKind.FAILURE
 import static org.spockframework.runtime.model.BlockKind.*
+import groovy.util.logging.Log
+import groovy.xml.MarkupBuilder
+
+import java.util.logging.Level
+
+import org.spockframework.runtime.model.BlockInfo
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.IterationInfo
+
+import spock.lang.Unroll
+
+import com.athaydes.spockframework.report.IReportCreator
 
 /**
  *
  * User: Renato
  */
+@Log
 class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 		implements IReportCreator {
 
@@ -51,12 +57,11 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 				new File( reportsDir, specClassName + '.html' )
 						.write( reportFor( data ) )
 			} catch ( e ) {
-				e.printStackTrace()
-				println "${this.class.name} failed to create report for $specClassName, Reason: $e"
+				log.log(Level.FINE, "${this.class.name} failed to create report for $specClassName", e)
 			}
 
 		} else {
-			println "${this.class.name} cannot create output directory: ${reportsDir.absolutePath}"
+			log.fine "${this.class.name} cannot create output directory: ${reportsDir.absolutePath}"
 		}
 	}
 


### PR DESCRIPTION
Convert `println` statements to `@Log` logging.  I converted existing println statements, you can add more logging as you see fit.

To go with the "silent by default" approach, I've logged all errors at `Level.FINE` and all informational messages at `Level.FINER`.  Most people's JVM logging will not log any of this by default.