### PR TITLE
Make sure to iterate over features in execution order

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/SpockReportExtension.groovy
@@ -167,7 +167,7 @@ class SpecInfoListener implements IRunListener {
                 def currentError = new ErrorInfo( errorInfo.method, new SpecInitializationError( errorInfo.exception ) )
 
                 // simulate all features failing
-                for ( featureInfo in errorInfo.method.parent.allFeatures ) {
+                for ( featureInfo in errorInfo.method.parent.allFeaturesInExecutionOrder ) {
                     markWithInitializationError featureInfo
                     beforeFeature featureInfo
                     error currentError

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregator.groovy
@@ -26,7 +26,7 @@ class HtmlReportAggregator extends AbstractHtmlCreator<Map> {
 
     void aggregateReport( SpecData data, Map stats ) {
         def specName = data.info.description.className
-        def allFeatures = data.info.allFeatures.groupBy { feature -> feature.skipped }
+        def allFeatures = data.info.allFeaturesInExecutionOrder.groupBy { feature -> feature.skipped }
 
         aggregatedData[ specName ] = Utils.createAggregatedData(
                 allFeatures[ false ], allFeatures[ true ], stats )

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -149,7 +149,7 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 
     private void writeFeatureToc( MarkupBuilder builder, SpecData data ) {
         builder.ul( id: 'toc' ) {
-            for ( FeatureInfo feature in data.info.allFeatures ) {
+            for ( FeatureInfo feature in data.info.allFeaturesInExecutionOrder ) {
                 FeatureRun run = data.featureRuns.find { it.feature == feature }
                 if ( run && Utils.isUnrolled( feature ) ) {
                     run.failuresByIteration.eachWithIndex { iteration, problems, int index ->
@@ -175,7 +175,7 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 
     private void writeFeature( MarkupBuilder builder, SpecData data ) {
         if ( excludeToc.toLowerCase() != 'true' ) writeFeatureToc( builder, data )
-        for ( FeatureInfo feature in data.info.allFeatures ) {
+        for ( FeatureInfo feature in data.info.allFeaturesInExecutionOrder ) {
             FeatureRun run = data.featureRuns.find { it.feature == feature }
             if ( run && Utils.isUnrolled( feature ) ) {
                 run.failuresByIteration.eachWithIndex { iteration, problems, int index ->

--- a/src/main/groovy/com/athaydes/spockframework/report/template/TemplateReportAggregator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/template/TemplateReportAggregator.groovy
@@ -18,7 +18,7 @@ class TemplateReportAggregator {
 
         def specName = data.info.description.className
         def stats = Utils.stats( data )
-        def allFeatures = data.info.allFeatures.groupBy { feature -> feature.skipped }
+        def allFeatures = data.info.allFeaturesInExecutionOrder.groupBy { feature -> feature.skipped }
 
         aggregatedData[ specName ] = Utils.createAggregatedData(
                 allFeatures[ false ], allFeatures[ true ], stats )

--- a/src/main/groovy/com/athaydes/spockframework/report/template/TemplateReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/template/TemplateReportCreator.groovy
@@ -79,7 +79,7 @@ class TemplateReportCreator implements IReportCreator {
 
     def createFeaturesCallback( SpecData data ) {
         return [ eachFeature: { Closure callback ->
-            for ( feature in data.info.allFeatures ) {
+            for ( feature in data.info.allFeaturesInExecutionOrder ) {
                 callback.delegate = feature
                 FeatureRun run = data.featureRuns.find { it.feature == feature }
                 if ( run && Utils.isUnrolled( feature ) ) {

--- a/src/main/groovy/com/athaydes/spockframework/report/util/Utils.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/util/Utils.groovy
@@ -47,7 +47,7 @@ class Utils {
     static Map stats( SpecData data ) {
         def failures = countProblems( data.featureRuns, this.&isFailure )
         def errors = countProblems( data.featureRuns, this.&isError )
-        def skipped = data.info.allFeatures.count { FeatureInfo f -> f.skipped }
+        def skipped = data.info.allFeaturesInExecutionOrder.count { FeatureInfo f -> f.skipped }
         def total = countFeatures( data.featureRuns )
         def successRate = successRate( total, ( errors + failures ).toInteger() )
         [ failures   : failures, errors: errors, skipped: skipped, totalRuns: total,

--- a/src/test/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregatorSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/internal/HtmlReportAggregatorSpec.groovy
@@ -117,7 +117,7 @@ class HtmlReportAggregatorSpec extends ReportSpec {
         def data = Stub( SpecData ) {
             getInfo() >> Stub( SpecInfo ) {
                 getDescription() >> Description.createTestDescription( 'myClass', 'myClass' )
-                getAllFeatures() >> [
+                getAllFeaturesInExecutionOrder() >> [
                         Stub( FeatureInfo ) {
                             isSkipped() >> false
                             getName() >> 'cFeature'


### PR DESCRIPTION
This pull request makes sure that iterations over `eachFeature` are done in execution order of the features. I have a use case, where the rendered features in the template must have the same order as the execution order. While I could not create a case where it failed, this pull request makes sure that it will (hopefully) never happen.