### PR TITLE
96 HtmlReportCreator and showCodeBlocks

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/internal/AbstractHtmlCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/AbstractHtmlCreator.groovy
@@ -15,11 +15,8 @@ abstract class AbstractHtmlCreator<T> {
     boolean doInlineCss = true
     String outputDirectory = ''
     boolean hideEmptyBlocks = false
-    boolean showCodeBlocks = false
-    String testSourceRoots
     KnowsWhenAndWhoRanTest whenAndWho = new KnowsWhenAndWhoRanTest()
     String excludeToc = "false"
-
     private String resolvedCss
 
     abstract String cssDefaultName()

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -2,6 +2,8 @@ package com.athaydes.spockframework.report.internal
 
 import com.athaydes.spockframework.report.IReportCreator
 import com.athaydes.spockframework.report.util.Utils
+import com.athaydes.spockframework.report.vivid.BlockCode
+import com.athaydes.spockframework.report.vivid.SpecSourceCodeReader
 import groovy.util.logging.Slf4j
 import groovy.xml.MarkupBuilder
 import org.spockframework.runtime.model.BlockInfo
@@ -29,17 +31,23 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
     def stringFormatter = new StringFormatHelper()
     def problemWriter = new ProblemBlockWriter( stringFormatter: stringFormatter )
     def stringProcessor = new StringTemplateProcessor()
+    private final SpecSourceCodeReader codeReader = new SpecSourceCodeReader()
+    boolean showCodeBlocks = false
     boolean enabled = true
 
     HtmlReportCreator() {
         reportAggregator = defaultAggregator
-        if ( showCodeBlocks ) {
-            log.warn( '"showCodeBlocks" is not implemented in HtmlReportCreator. Use TemplateReportCreator.' )
-        }
     }
 
     HtmlReportCreator( HtmlReportAggregator reportAggregator ) {
         this.reportAggregator = reportAggregator
+    }
+
+    @Override
+    void setTestSourceRoots( String roots ) {
+        if ( roots ) {
+            codeReader.testSourceRoots = roots
+        }
     }
 
     void setFeatureReportCss( String css ) {
@@ -103,6 +111,9 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
         def reportsDir = outputDirectory ? Utils.createDir( outputDirectory ) : null
         if ( reportsDir?.isDirectory() ) {
             try {
+                if ( showCodeBlocks ) {
+                    codeReader.read( data )
+                }
                 new File( reportsDir, specClassName + '.html' )
                         .write( reportFor( data ) )
             } catch ( e ) {
@@ -246,37 +257,85 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 
 
     private void writeFeatureBlocks( MarkupBuilder builder, FeatureInfo feature, IterationInfo iteration = null ) {
-        for ( BlockInfo block in feature.blocks ) {
-            writeBlock( builder, block, feature, iteration )
+        if ( showCodeBlocks ){
+            writeBlocksFromCode( builder, feature, iteration )
+        } else {
+            writeBlocks( builder, feature, iteration )
         }
     }
 
-    private void writeBlock( MarkupBuilder builder, BlockInfo block, FeatureInfo feature, IterationInfo iteration ) {
-        def trCssClassArg = ( feature.skipped ? [ 'class': 'ignored' ] : null )
-        if ( !Utils.isEmptyOrContainsOnlyEmptyStrings( block.texts ) )
-            block.texts.eachWithIndex { blockText, index ->
-                if ( iteration ) {
-                    blockText = stringProcessor.process( blockText, feature.dataVariables, iteration )
+    private void writeBlocks( MarkupBuilder builder, FeatureInfo feature, IterationInfo iteration ) {
+        for ( BlockInfo block in feature.blocks ) {
+            if ( !Utils.isEmptyOrContainsOnlyEmptyStrings( block.texts ) )
+                block.texts.eachWithIndex { blockText, index ->
+                    if ( iteration ) {
+                        blockText = stringProcessor.process( blockText, feature.dataVariables, iteration )
+                    }
+                    writeBlockRow( builder, trCssClass( feature ),
+                            ( index == 0 ? block.kind : 'and' ), blockText )
                 }
-                writeBlockRow( builder, trCssClassArg,
-                        ( index == 0 ? block.kind : 'and' ), blockText )
+            else if ( !hideEmptyBlocks ) {
+                writeBlockRow( builder, trCssClass( feature ), block.kind, '----' )
             }
-        else if ( !hideEmptyBlocks )
-            writeBlockRow( builder, trCssClassArg, block.kind, '----' )
+        }
+    }
+
+    private void writeBlocksFromCode( MarkupBuilder builder, FeatureInfo feature, IterationInfo iteration ) {
+        def blocks = codeReader.getBlocks( feature )
+        for ( BlockCode block in blocks ) {
+            def text = iteration && block.text ?
+                    stringProcessor.process( block.text, feature.dataVariables, iteration ) :
+                    ( block.text ?: '' )
+            def blockKind = block.label ?: 'Block:'
+            if ( text ) {
+                writeBlockRowFromCodeAndText( builder, trCssClass( feature ), blockKind, block.statements, text )
+            } else  {
+                writeBlockRowFromCodeOnly( builder, trCssClass( feature ), blockKind, block.statements )
+            }
+        }
+    }
+
+    private trCssClass( FeatureInfo feature ) {
+        feature.skipped ? [ 'class': 'ignored' ] : null
     }
 
     private writeBlockRow( MarkupBuilder builder, cssClass, blockKind, text ) {
         builder.tr( cssClass ) {
             writeBlockKindTd( builder, blockKind )
-            td {
-                div( 'class': 'block-text', text )
-            }
+            writeBlockTextTd( builder, text )
         }
     }
 
-    private void writeBlockKindTd( MarkupBuilder builder, blockKindKey ) {
+    private writeBlockRowFromCodeAndText( MarkupBuilder builder, cssClass, blockKind, List statements, text ) {
+        writeBlockRow ( builder, cssClass, blockKind, text )
+        if ( statements ) builder.tr {
+            td {}
+            writeCodeTd( builder, statements )
+        }
+    }
+
+    private writeBlockRowFromCodeOnly( MarkupBuilder builder, cssClass, blockKind, List statements ) {
+        if ( statements ) builder.tr( cssClass ) {
+            writeBlockKindTd( builder, blockKind )
+            writeCodeTd( builder, statements )
+        }
+    }
+
+    private void writeBlockKindTd( MarkupBuilder builder, blockKind ) {
         builder.td {
-            div( 'class': 'block-kind', Utils.block2String[ blockKindKey ] )
+            div( 'class': 'block-kind', Utils.block2String[ blockKind ] )
+        }
+    }
+
+    private void writeBlockTextTd( MarkupBuilder builder, text ) {
+        builder.td {
+            div( 'class': 'block-text', text )
+        }
+    }
+
+    private writeCodeTd( MarkupBuilder builder, List statements ) {
+        builder.td {
+            pre( 'class': 'block-text', statements.join('\n') )
         }
     }
 

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -287,11 +287,7 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
                     stringProcessor.process( block.text, feature.dataVariables, iteration ) :
                     ( block.text ?: '' )
             def blockKind = block.label ?: 'Block:'
-            if ( text ) {
-                writeBlockRowFromCodeAndText( builder, trCssClass( feature ), blockKind, block.statements, text )
-            } else  {
-                writeBlockRowFromCodeOnly( builder, trCssClass( feature ), blockKind, block.statements )
-            }
+            writeBlockRowsFromCode( builder, trCssClass( feature ), blockKind, block.statements, text )
         }
     }
 
@@ -306,16 +302,14 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
         }
     }
 
-    private writeBlockRowFromCodeAndText( MarkupBuilder builder, cssClass, blockKind, List statements, text ) {
-        writeBlockRow ( builder, cssClass, blockKind, text )
-        if ( statements ) builder.tr {
-            td {}
-            writeCodeTd( builder, statements )
-        }
-    }
-
-    private writeBlockRowFromCodeOnly( MarkupBuilder builder, cssClass, blockKind, List statements ) {
-        if ( statements ) builder.tr( cssClass ) {
+    private writeBlockRowsFromCode( MarkupBuilder builder, cssClass, blockKind, List statements, text ) {
+        if ( text ) {
+            writeBlockRow ( builder, cssClass, blockKind, text )
+            if ( statements ) builder.tr {
+                td()
+                writeCodeTd( builder, statements )
+            }
+        } else if ( statements ) builder.tr( cssClass ) {
             writeBlockKindTd( builder, blockKind )
             writeCodeTd( builder, statements )
         }
@@ -335,7 +329,7 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 
     private writeCodeTd( MarkupBuilder builder, List statements ) {
         builder.td {
-            pre( 'class': 'block-text', statements.join('\n') )
+            pre( 'class': 'block-source', statements.join('\n') )
         }
     }
 

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
@@ -58,7 +58,7 @@ class SpecSourceCodeCollector {
             return
         }
 
-        println "LABEL: $label -> $code"
+        log.debug( "LABEL: $label -> $code" )
         if ( label ) {
             def labelText = stringConstant( statement )
             specCode.startBlock( method, label, labelText )

--- a/src/test/groovy/com/athaydes/spockframework/report/VividFakeTest.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/VividFakeTest.groovy
@@ -7,9 +7,8 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 @Narrative( """
-As a user
-I want foo
-So that bar""" )
+As a developer
+I want to see my code""" )
 class VividFakeTest extends Specification {
 
     def "A first test with Then code block"() {

--- a/src/test/groovy/com/athaydes/spockframework/report/template/TemplateReportCreatorSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/template/TemplateReportCreatorSpec.groovy
@@ -5,6 +5,7 @@ import com.athaydes.spockframework.report.SpecInfoListener
 import com.athaydes.spockframework.report.SpockReportExtension
 import com.athaydes.spockframework.report.VividFakeTest
 import com.athaydes.spockframework.report.internal.HtmlReportCreatorSpec
+import com.athaydes.spockframework.report.internal.StringFormatHelper
 import org.junit.runner.notification.RunNotifier
 import org.spockframework.runtime.Sputnik
 import spock.lang.Specification
@@ -47,6 +48,7 @@ class TemplateReportCreatorSpec extends Specification {
         this.class.getResource("/${specName}.md")
                 .text
                 .replace('${projectUrl}', SpockReportExtension.PROJECT_URL)
+                .replace('${ds}', StringFormatHelper.ds as String)
                 .replaceAll("\r", '')
     }
 

--- a/src/test/resources/FakeTest.md
+++ b/src/test/resources/FakeTest.md
@@ -3,7 +3,7 @@
 ##Summary
 
 * Total Runs: 10
-* Success Rate: 50.0%
+* Success Rate: 50${ds}0%
 * Failures: 3
 * Errors:   2
 * Skipped:  1

--- a/src/test/resources/VividFakeTest.md
+++ b/src/test/resources/VividFakeTest.md
@@ -10,9 +10,8 @@
 * Total time: Unknown
 
 <pre>
-As a user
-I want foo
-So that bar
+As a developer
+I want to see my code
 </pre>
 
 ## Features

--- a/src/test/resources/VividFakeTest.md
+++ b/src/test/resources/VividFakeTest.md
@@ -3,7 +3,7 @@
 ##Summary
 
 * Total Runs: 9
-* Success Rate: 44.44%
+* Success Rate: 44${ds}44%
 * Failures: 3
 * Errors:   2
 * Skipped:  0

--- a/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
+++ b/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv='Content-Type' content='text/html; charset=utf-8'></meta>
+	<style>
+		${style}
+	</style>
+</head>
+<body>
+<h2>Report for ${classOnTest}</h2>
+<hr></hr>
+<div class='summary-report'>
+	<h3>Summary:</h3>
+	<div class='date-test-ran'>Created on ${dateTestRan} by ${username}</div>
+	<table class='summary-table'>
+		<thead>
+		<th>Executed features</th>
+		<th>Failures</th>
+		<th>Errors</th>
+		<th>Skipped</th>
+		<th>Success rate</th>
+		<th>Time</th>
+		</thead>
+		<tbody>
+		<tr>
+			<td>${executedFeatures}</td>
+			<td>${failures}</td>
+			<td>${errors}</td>
+			<td>${skipped}</td>
+			<td>${successRate}</td>
+			<td>${time}</td>
+		</tr>
+		</tbody>
+	</table>
+</div>
+<pre class='narrative'>${narrative}</pre>
+<h3>Features:</h3>
+<table class='features-table'>
+<colgroup>
+	<col class='block-kind-col'></col>
+	<col class='block-text-col'></col>
+</colgroup>
+<tbody>
+<div>TOC</div>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description failure' id='0'><span>A first test with Then code block</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>we have x and y</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>And:</div>
+	</td>
+	<td>
+		<div class='block-text'>some more things</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>When:</div>
+	</td>
+	<td>
+		<div class='block-text'>I do crazy things</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Then:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Where:</div>
+	</td>
+	<td>
+		<div class='block-text'>The examples below are used</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Examples:</div>
+	</td>
+	<td>
+		<div class='spec-examples'>
+			<table class='ex-table'>
+				<thead>
+				<th class='ex-header'>x</th>
+				<th class='ex-header'>y</th>
+				</thead>
+				<tbody>
+				<tr class='ex-pass'>
+					<td class='ex-value'>a</td>
+					<td class='ex-value'>a</td>
+					<td class='ex-result'>OK</td>
+				</tr>
+				<tr class='ex-fail'>
+					<td class='ex-value'>b</td>
+					<td class='ex-value'>c</td>
+					<td class='ex-result'>FAIL</td>
+				</tr>
+				</tbody>
+			</table>
+		</div>
+	</td>
+	<td>
+		<div class='spec-status'>1/2 passed</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='problem-description'>
+			<div class='problem-header'>The following problems occurred:</div>
+			<div class='problem-list'>
+				<ul>
+					<li>
+						<div>[b, c]</div>
+						<ul>
+							<li>
+								<pre>Condition not satisfied:<br/><br/>x == y<br/>| |  |<br/>b |  c<br/>  false<br/>  1 difference (0% similarity)<br/>  (b)<br/>  (c)<br/></pre>
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description' id='1'><span>Another feature without code</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>Setup block here</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Expect:</div>
+	</td>
+	<td>
+		<div class='block-text'>Expecting something ??</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description' id='2'><span>Another feature with method call</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Expect:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description error' id='3'>
+			<span>A test with an error</span>
+			<span style='float: right; font-size: 60%;'><a href='#toc'>Return</a></span>
+			<div class='issues'>
+				<div>Issues:</div>
+				<ul>
+					<li><a href='http://myhost.com/issues/995'>http://myhost.com/issues/995</a></li>
+					<li><a href='http://myhost.com/issues/973'>http://myhost.com/issues/973</a></li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>When:</div>
+	</td>
+	<td>
+		<div class='block-text'>An Exception is thrown</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Then:</div>
+	</td>
+	<td>
+		<div class='block-text'>Will never succeed</div>
+	</td>
+</tr>
+<tr>
+<td colspan='10'>
+	<div class='problem-description'>
+		<div class='problem-header'>The following problems occurred:</div>
+		<div class='problem-list'>
+			<ul>
+				<li>
+					<pre>java.lang.RuntimeException: As expected</pre>
+				</li>
+			</ul>
+		</div>
+	</div>
+</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description failure' id='4'><span>A test with a failure</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span>
+			<div class='issues'>
+				<div>See:</div>
+				<ul>
+					<li><a href='http://myhost.com/features/feature-234'>http://myhost.com/features/feature-234</a></li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>When:</div>
+	</td>
+	<td>
+		<div class='block-text'>Do nothing</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Then:</div>
+	</td>
+	<td>
+		<div class='block-text'>Test fails</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='problem-description'>
+			<div class='problem-header'>The following problems occurred:</div>
+			<div class='problem-list'>
+				<ul>
+					<li>
+						<pre>Condition not satisfied:<br/><br/>3 == 2<br/>  |<br/>  false<br/></pre>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description' id='5'>
+			<span>A Spec without block Strings</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>When:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Then:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description' id='6'><span>An @Unrolled spec with x=0 and y=1</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>nothing</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Expect:</div>
+	</td>
+	<td>
+		<div class='block-text'>An error if y is 5</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Where:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description failure' id='7'><span>An @Unrolled spec with x=2 and y=3</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>nothing</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Expect:</div>
+	</td>
+	<td>
+		<div class='block-text'>An error if y is 5</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Where:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='problem-description'>
+			<div class='problem-header'>The following problems occurred:</div>
+			<div class='problem-list'>
+				<ul>
+					<li>
+						<pre>Condition not satisfied:<br/><br/>x == 0<br/>| |<br/>2 false<br/></pre>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='feature-description error' id='8'><span>An @Unrolled spec with x=0 and y=5</span><span style='float: right; font-size: 60%;'>
+            <a href='#toc'>Return</a></span></div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Given:</div>
+	</td>
+	<td>
+		<div class='block-text'>nothing</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Expect:</div>
+	</td>
+	<td>
+		<div class='block-text'>An error if y is 5</div>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>Where:</div>
+	</td>
+	<td>
+		<div class='block-text'>----</div>
+	</td>
+</tr>
+<tr>
+	<td colspan='10'>
+		<div class='problem-description'>
+			<div class='problem-header'>The following problems occurred:</div>
+			<div class='problem-list'>
+				<ul>
+					<li>
+						<pre>java.lang.RuntimeException: y is 5</pre>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</td>
+</tr>
+</tbody>
+</table>
+<hr></hr>
+<div class='footer'>Generated by <a href='${projectUrl}'>Athaydes Spock Reports</a></div>
+</body>
+</html>

--- a/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
+++ b/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
@@ -77,7 +77,7 @@
 		<div class='block-kind'>Then:</div>
 	</td>
 	<td>
-		<pre class='block-text'>x == y</pre>
+		<pre class='block-source'>x == y</pre>
 	</td>
 </tr>
 <tr>
@@ -170,7 +170,7 @@
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<pre class='block-text'>add( 1, 2 ) == 3</pre>
+		<pre class='block-source'>add( 1, 2 ) == 3</pre>
 	</td>
 </tr>
 <tr>
@@ -199,7 +199,7 @@
 <tr>
 	<td></td>
 	<td>
-		<pre class='block-text'>throw new RuntimeException( 'As expected' )</pre>
+		<pre class='block-source'>throw new RuntimeException( 'As expected' )</pre>
 	</td>
 </tr>
 <tr>
@@ -256,7 +256,7 @@
 <tr>
 	<td></td>
 	<td>
-		<pre class='block-text'>assert 3 == 2</pre>
+		<pre class='block-source'>assert 3 == 2</pre>
 	</td>
 </tr>
 <tr>
@@ -286,7 +286,7 @@
 		<div class='block-kind'>Given:</div>
 	</td>
 	<td>
-		<pre class='block-text'>int a = 0</pre>
+		<pre class='block-source'>int a = 0</pre>
 	</td>
 </tr>
 <tr>
@@ -294,7 +294,7 @@
 		<div class='block-kind'>And:</div>
 	</td>
 	<td>
-<pre class='block-text'>int b = 1
+<pre class='block-source'>int b = 1
 int c = 2
 int d = b + c</pre>
 	</td>
@@ -304,7 +304,7 @@ int d = b + c</pre>
 		<div class='block-kind'>When:</div>
 	</td>
 	<td>
-		<pre class='block-text'>int e = a + b + c + d</pre>
+		<pre class='block-source'>int e = a + b + c + d</pre>
 	</td>
 </tr>
 <tr>
@@ -312,7 +312,7 @@ int d = b + c</pre>
 		<div class='block-kind'>Then:</div>
 	</td>
 	<td>
-<pre class='block-text'>e == 6
+<pre class='block-source'>e == 6
 a == 0
 c == 2 * b</pre>
 	</td>
@@ -322,7 +322,7 @@ c == 2 * b</pre>
 		<div class='block-kind'>And:</div>
 	</td>
 	<td>
-		<pre class='block-text'>c &gt; 0</pre>	</td>
+		<pre class='block-source'>c &gt; 0</pre>	</td>
 </tr>
 <tr>
 	<td colspan='10'>
@@ -343,7 +343,7 @@ c == 2 * b</pre>
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<pre class='block-text'>x == 0</pre>
+		<pre class='block-source'>x == 0</pre>
 	</td>
 </tr>
 <tr>
@@ -357,7 +357,7 @@ c == 2 * b</pre>
 <tr>
 	<td></td>
 	<td>
-		<pre class='block-text'>if ( y == 5 ) {
+		<pre class='block-source'>if ( y == 5 ) {
     throw new RuntimeException( 'y is 5' )
 }</pre></td>
 </tr>
@@ -380,7 +380,7 @@ c == 2 * b</pre>
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<pre class='block-text'>x == 0</pre>
+		<pre class='block-source'>x == 0</pre>
 	</td>
 </tr>
 <tr>
@@ -394,7 +394,7 @@ c == 2 * b</pre>
 <tr>
 	<td></td>
 	<td>
-<pre class='block-text'>if ( y == 5 ) {
+<pre class='block-source'>if ( y == 5 ) {
     throw new RuntimeException( 'y is 5' )
 }</pre>
 	</td>
@@ -432,7 +432,7 @@ c == 2 * b</pre>
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<pre class='block-text'>x == 0</pre>
+		<pre class='block-source'>x == 0</pre>
 	</td>
 </tr>
 <tr>
@@ -446,7 +446,7 @@ c == 2 * b</pre>
 <tr>
 	<td></td>
 	<td>
-<pre class='block-text'>if ( y == 5 ) {
+<pre class='block-source'>if ( y == 5 ) {
     throw new RuntimeException( 'y is 5' )
 }</pre>
 	</td>

--- a/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
+++ b/src/test/resources/com/athaydes/spockframework/report/internal/VividFakeTestReport.html
@@ -77,7 +77,7 @@
 		<div class='block-kind'>Then:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<pre class='block-text'>x == y</pre>
 	</td>
 </tr>
 <tr>
@@ -170,7 +170,7 @@
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<pre class='block-text'>add( 1, 2 ) == 3</pre>
 	</td>
 </tr>
 <tr>
@@ -194,6 +194,12 @@
 	</td>
 	<td>
 		<div class='block-text'>An Exception is thrown</div>
+	</td>
+</tr>
+<tr>
+	<td></td>
+	<td>
+		<pre class='block-text'>throw new RuntimeException( 'As expected' )</pre>
 	</td>
 </tr>
 <tr>
@@ -248,6 +254,12 @@
 	</td>
 </tr>
 <tr>
+	<td></td>
+	<td>
+		<pre class='block-text'>assert 3 == 2</pre>
+	</td>
+</tr>
+<tr>
 	<td colspan='10'>
 		<div class='problem-description'>
 			<div class='problem-header'>The following problems occurred:</div>
@@ -274,7 +286,17 @@
 		<div class='block-kind'>Given:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<pre class='block-text'>int a = 0</pre>
+	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>And:</div>
+	</td>
+	<td>
+<pre class='block-text'>int b = 1
+int c = 2
+int d = b + c</pre>
 	</td>
 </tr>
 <tr>
@@ -282,7 +304,7 @@
 		<div class='block-kind'>When:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<pre class='block-text'>int e = a + b + c + d</pre>
 	</td>
 </tr>
 <tr>
@@ -290,8 +312,17 @@
 		<div class='block-kind'>Then:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+<pre class='block-text'>e == 6
+a == 0
+c == 2 * b</pre>
 	</td>
+</tr>
+<tr>
+	<td>
+		<div class='block-kind'>And:</div>
+	</td>
+	<td>
+		<pre class='block-text'>c &gt; 0</pre>	</td>
 </tr>
 <tr>
 	<td colspan='10'>
@@ -312,16 +343,23 @@
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<div class='block-text'>An error if y is 5</div>
+		<pre class='block-text'>x == 0</pre>
 	</td>
 </tr>
 <tr>
 	<td>
-		<div class='block-kind'>Where:</div>
+		<div class='block-kind'>And:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<div class='block-text'>An error if y is 5</div>
 	</td>
+</tr>
+<tr>
+	<td></td>
+	<td>
+		<pre class='block-text'>if ( y == 5 ) {
+    throw new RuntimeException( 'y is 5' )
+}</pre></td>
 </tr>
 <tr>
 	<td colspan='10'>
@@ -342,15 +380,23 @@
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<div class='block-text'>An error if y is 5</div>
+		<pre class='block-text'>x == 0</pre>
 	</td>
 </tr>
 <tr>
 	<td>
-		<div class='block-kind'>Where:</div>
+		<div class='block-kind'>And:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<div class='block-text'>An error if y is 5</div>
+	</td>
+</tr>
+<tr>
+	<td></td>
+	<td>
+<pre class='block-text'>if ( y == 5 ) {
+    throw new RuntimeException( 'y is 5' )
+}</pre>
 	</td>
 </tr>
 <tr>
@@ -386,15 +432,23 @@
 		<div class='block-kind'>Expect:</div>
 	</td>
 	<td>
-		<div class='block-text'>An error if y is 5</div>
+		<pre class='block-text'>x == 0</pre>
 	</td>
 </tr>
 <tr>
 	<td>
-		<div class='block-kind'>Where:</div>
+		<div class='block-kind'>And:</div>
 	</td>
 	<td>
-		<div class='block-text'>----</div>
+		<div class='block-text'>An error if y is 5</div>
+	</td>
+</tr>
+<tr>
+	<td></td>
+	<td>
+<pre class='block-text'>if ( y == 5 ) {
+    throw new RuntimeException( 'y is 5' )
+}</pre>
 	</td>
 </tr>
 <tr>


### PR DESCRIPTION
Now showCodeBlocks works in HtmlReportCreator also. Example part of rendered html report:

```
A Spec without block Strings Return
Given: int a = 0
And: int b = 1
 int c = 2
 int d = b + c
When: int e = a + b + c + d
Then: e == 6
 a == 0
 c == 2 * b
And: c > 0

An @Unrolled spec with x=0 and y=1 Return
Given: nothing
Expect: x == 0
And: An error if y is 5
 if ( y == 5 ) {
     throw new RuntimeException( 'y is 5' )
 }
```