### PR TITLE
fix and test #231 (code blocks are not shown for annotated features)

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
@@ -154,12 +154,7 @@ class VividASTVisitor extends ClassCodeVisitorSupport {
 
     @Override // This is overridden to avoid visiting annotations.
     void visitAnnotations(AnnotatedNode node) {
-        for (AnnotationNode annotation : node.getAnnotations()) {
-            // skip built-in properties
-            if (!annotation.isBuiltIn()) {
-                //visitAnnotation(annotation);
-            }
-        }
+        // do nothing - we don't want to visit annotations (see #231)
     }
 
     @Override

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
@@ -1,18 +1,12 @@
 package com.athaydes.spockframework.report.vivid
 
-import com.athaydes.spockframework.report.vivid.VividAstInspector.AstSuccessfullyCaptured
+
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import org.codehaus.groovy.ast.ClassCodeVisitorSupport
-import org.codehaus.groovy.ast.ClassNode
-import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.*
 import org.codehaus.groovy.ast.stmt.BlockStatement
 import org.codehaus.groovy.ast.stmt.Statement
-import org.codehaus.groovy.control.CompilationFailedException
-import org.codehaus.groovy.control.CompilationUnit
-import org.codehaus.groovy.control.CompilePhase
-import org.codehaus.groovy.control.CompilerConfiguration
-import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.control.*
 import org.spockframework.util.Nullable
 import org.spockframework.util.inspector.AstInspectorException
 
@@ -156,6 +150,16 @@ class VividASTVisitor extends ClassCodeVisitorSupport {
         codeCollector.method = null
 
         visitStatements = previousIsTestMethod
+    }
+
+    @Override // This is overridden to avoid visiting annotations.
+    void visitAnnotations(AnnotatedNode node) {
+        for (AnnotationNode annotation : node.getAnnotations()) {
+            // skip built-in properties
+            if (!annotation.isBuiltIn()) {
+                //visitAnnotation(annotation);
+            }
+        }
     }
 
     @Override

--- a/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
@@ -379,4 +379,35 @@ class VividAstInspectorSpec extends Specification {
         blocks[ 2 ].text == 'the result is right'
     }
 
+    def "Vivid AST Inspector can ignore annotations."() {
+        given: 'A Groovy source file with an annotated feature'
+        def groovySource = '''|
+        |class Abc extends Specification {
+        |  @IgnoreIf({something==true})
+        |  def "my annotated feature"() {
+        |    expect: 'the result is right!'
+        |    42 == 42
+        |  }
+        |}'''.stripMargin()
+
+        def groovyFile = File.createTempFile( 'spock-reports', 'groovy' )
+        groovyFile << groovySource
+
+        when: 'The Groovy file is loaded by the inspector'
+        def result = inspector.load( groovyFile, 'Abc' )
+
+        and: 'The code blocks are requested'
+        def blocks = result.getBlocks( 'my annotated feature' )
+
+        then: 'The correct number of blocks is parsed'
+        blocks.size() == 1
+
+        and: 'The inspector should be able to provide the source code for each block'
+        blocks[ 0 ].statements == [ '42 == 42' ]
+
+        and: 'The blocks should have the expected label and text'
+        blocks[ 0 ].label == 'expect'
+        blocks[ 0 ].text == 'the result is right!'
+    }
+
 }


### PR DESCRIPTION
It looks like annotations cause the `VividASTVisitor` to ignore the blocks of a specification method.
I fixed it by overriding the method doing the annotation visiting and skipping the traversal of the annotation code entirely...

My fix did not cause any regressions in the test suite and
I also added an additional test in order to make sure that this bug does not come back some day...