### PR TITLE
Fix (#235) VividAstInspector not accounting for indents 

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/CustomSourceLookup.java
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/CustomSourceLookup.java
@@ -1,0 +1,35 @@
+package com.athaydes.spockframework.report.vivid;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.Janitor;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ *  A modified version  of {@link org.spockframework.compiler.SourceLookup} which does not
+ *  trim the indents of the source code read from provided {@link ASTNode} instances.
+ */
+public class CustomSourceLookup {
+    private final SourceUnit sourceUnit;
+    private final Janitor janitor = new Janitor();
+
+    public CustomSourceLookup( SourceUnit sourceUnit ) { this.sourceUnit = sourceUnit; }
+
+    public String lookup( ASTNode node ) {
+        StringBuilder text = new StringBuilder();
+        for ( int i = node.getLineNumber(); i <= node.getLastLineNumber(); i++ ) {
+            String line = sourceUnit.getSample(i, 0, janitor);
+            if ( line == null )
+                return null; // most probably a Groovy bug, but we prefer to handle this situation gracefully
+
+            try {
+                if ( i == node.getLastLineNumber() ) line = line.substring(0, node.getLastColumnNumber() - 1);
+                text.append( line );
+                if ( i != node.getLastLineNumber() ) text.append('\n');
+            } catch ( StringIndexOutOfBoundsException e ) {
+                return null; // most probably a Groovy bug, but we prefer to handle this situation gracefully
+            }
+        }
+        return text.toString();
+    }
+}
+

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCode.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCode.groovy
@@ -24,10 +24,10 @@ class SpecSourceCode {
         sourceCodeByFeatureName.get( feature.name, new FeatureSourceCode() ).startBlock( label, text )
     }
 
-    void addStatement( MethodNode feature, String statement, int lineNumber ) {
+    void addStatement( MethodNode feature, String statement, int lineNumber, int commonIndent ) {
         def currentFeature = sourceCodeByFeatureName[ feature.name ]
         if ( currentFeature ) {
-            statement = removeIndent( statement )
+            statement = removeIndent( statement, commonIndent )
             currentFeature.addStatement( statement, lineNumber )
         } else {
             log.debug( "Skipping statement on method {}, not a test method?", feature?.name )
@@ -52,18 +52,19 @@ class SpecSourceCode {
         return result ?: [ ]
     }
 
-    static String removeIndent( String code ) {
+    static String removeIndent( String code, int commonIndent = Integer.MAX_VALUE ) {
+
+        if ( code.isEmpty() ) return code
+
         def lines = code.readLines()
-        if ( lines.size() < 2 ) {
-            return code
-        }
 
         // do not use the first line because the first line never gets any indentation
-        def firstTextIndexes = lines[ 1..-1 ].collect { String line -> line.findIndexOf { it != ' ' } }
+        def firstTextIndexes = lines[ 0..-1 ].collect { String line -> line.findIndexOf { it != ' ' } }
         def minIndent = firstTextIndexes.min()
+        minIndent = Math.min( minIndent, commonIndent )
 
         if ( minIndent > 0 ) {
-            def resultLines = [ lines[ 0 ] ] + lines[ 1..-1 ].collect { String line -> line.substring( minIndent ) }
+            def resultLines = lines[ 0..-1 ].collect { String line -> line.substring( minIndent ) }
             return resultLines.join( '\n' )
         } else {
             return code

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
@@ -9,7 +9,6 @@ import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
 import org.codehaus.groovy.ast.stmt.Statement
 import org.codehaus.groovy.control.SourceUnit
-import org.spockframework.compiler.SourceLookup
 import org.spockframework.util.Nullable
 
 import java.util.concurrent.ConcurrentHashMap
@@ -18,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 @CompileStatic
 class SpecSourceCodeCollector {
 
-    final SourceLookup sourceLookup
+    final CustomSourceLookup sourceLookup
     final ModuleNode module
 
     private static final Map<String, SpecSourceCode> specSourceCodeByClassName = [ : ] as ConcurrentHashMap
@@ -29,7 +28,7 @@ class SpecSourceCodeCollector {
     private MethodNode method
 
     SpecSourceCodeCollector( SourceUnit sourceUnit ) {
-        this.sourceLookup = new SourceLookup( sourceUnit )
+        this.sourceLookup = new CustomSourceLookup( sourceUnit )
         this.module = sourceUnit.AST
     }
 
@@ -58,7 +57,7 @@ class SpecSourceCodeCollector {
         sourceCode
     }
 
-    void add( Statement statement ) {
+    void add( Statement statement, int commonIndent ) {
         assert className && method
 
         def label = statement.statementLabel
@@ -81,12 +80,12 @@ class SpecSourceCodeCollector {
         }
 
         if ( label != 'where' ) { // the where statement must not be added to the code in the report
-            specCode.addStatement( method, code, statement.lineNumber )
+            specCode.addStatement( method, code, statement.lineNumber, commonIndent )
         }
     }
 
     @Nullable
-    private static String stringConstant( Statement statement ) {
+    static String stringConstant( Statement statement ) {
         if ( statement instanceof ExpressionStatement ) {
             def expr = ( statement as ExpressionStatement ).expression
             if ( expr instanceof ConstantExpression && expr.type.name == 'java.lang.String' ) {

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
@@ -162,9 +162,9 @@ class VividASTVisitor extends ClassCodeVisitorSupport {
         if ( visitStatements && node instanceof BlockStatement ) {
             def statements = filterStatements( ( node as BlockStatement ).statements )
             /*
-                First we find the smallest common indent level for all
-                code lines (excluding block statements),
-                which will be trimmed from all lines later on.
+                First we find the smallest common indent levels for all
+                code lines within a code block (excluding block statements),
+                which will be trimmed from the block lines when added to the code collector.
              */
             int blockIndent = Integer.MAX_VALUE // start with the maximum possible indent.
             List<Statement> blockStatements = [] // the statements of a block (given, when, then, etc.)

--- a/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
@@ -411,7 +411,7 @@ class VividAstInspectorSpec extends Specification {
     }
 
     def "Vivid AST Inspector preserves relative indents."() {
-        given: 'A Groovy source file with an annotated feature'
+        given: 'A Groovy source file with weired indents'
         def groovySource = '''|
         |class Xyz extends Specification {
         |  def "my indented feature"() {

--- a/src/test/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeSpec.groovy
@@ -5,7 +5,7 @@ import spock.lang.Specification
 class SpecSourceCodeSpec extends Specification {
 
     def "Source code indentation can be removed"() {
-        when: 'we remove the identation of some piece of code'
+        when: 'we remove the indentation of some piece of code'
         def result = SpecSourceCode.removeIndent( code )
 
         then: 'the code should look correct without indentation'
@@ -21,7 +21,7 @@ class SpecSourceCodeSpec extends Specification {
         |  println 2 * i
         |}'''.stripMargin() | 'for (i in x) {\n  println i\n  println 2 * i\n}'
 
-        '''for (i in x) {
+        '''        for (i in x) {
           println i
           println 2 * i
         }'''                | 'for (i in x) {\n  println i\n  println 2 * i\n}'


### PR DESCRIPTION
I fixed the bug described in #235, however
there were 2 places where I had to adjust the specifications in the test suite
because the expected results were also missing indents.
I hope these changes are fine, nothing is broken and I already tested
these changes on 1400+ tests, the reports were all generated well.

I also added a new test which ensures that indents are preserved.