### PR TITLE
Fix #237, where code blocks are missing their source code

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -391,7 +391,7 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
 
     private writeBlockRowsFromCode( MarkupBuilder builder, cssClass, blockKind,
                                     BlockCode code, text, int failureLineNumber ) {
-        def statements = code.statements
+        def statements = ( blockKind == 'where' ? [] : code.statements )
         def lineNumbers = code.lineNumbers
 
         if ( text ) {

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/SpecSourceCodeCollector.groovy
@@ -79,10 +79,8 @@ class SpecSourceCodeCollector {
                 return // don't add the text to the code
             }
         }
-
-        if ( label != 'where' ) { // the where statement must not be added to the code in the report
-            specCode.addStatement( method, code, statement.lineNumber )
-        }
+        // All statements must be added to the code in the report
+        specCode.addStatement( method, code, statement.lineNumber )
     }
 
     @Nullable

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
@@ -168,19 +168,12 @@ class VividASTVisitor extends ClassCodeVisitorSupport {
     void visitStatement( Statement node ) {
         if ( visitStatements && node instanceof BlockStatement ) {
             def stmts = ( node as BlockStatement ).statements
-            def waitForNextBlock = false
-            if ( stmts ) for ( statement in stmts ) {
-                if ( waitForNextBlock && !statement.statementLabel ) {
-                    continue // skip statements in this block
-                } else {
-                    waitForNextBlock = false
+            if ( stmts )
+                for ( statement in stmts ) {
+                    codeCollector.add( statement )
                 }
-
-                codeCollector.add( statement )
-            }
             visitStatements = false
         }
-
         super.visitStatement( node )
     }
 

--- a/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/vivid/VividAstInspector.groovy
@@ -177,10 +177,6 @@ class VividASTVisitor extends ClassCodeVisitorSupport {
                 }
 
                 codeCollector.add( statement )
-
-                if ( statement.statementLabel == 'where' ) {
-                    waitForNextBlock = true
-                }
             }
             visitStatements = false
         }

--- a/src/main/resources/templateReportCreator/spec-template.md
+++ b/src/main/resources/templateReportCreator/spec-template.md
@@ -87,7 +87,7 @@ Time: $totalTime
  %>
 * ${block.kind} ${block.text}
 <%
-          if ( block.sourceCode ) {
+          if ( block.sourceCode && block.kind != 'Where:' ) {
               out << "\n```\n"
               block.sourceCode.each { codeLine ->
                   out << codeLine << '\n'

--- a/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
+++ b/src/test/groovy/com/athaydes/spockframework/report/internal/VividAstInspectorSpec.groovy
@@ -96,7 +96,7 @@ class VividAstInspectorSpec extends Specification {
         blocks[ 1 ].statements.isEmpty()
         blocks[ 2 ].statements.isEmpty()
         blocks[ 3 ].statements == [ 'x == y' ]
-        blocks[ 4 ].statements.isEmpty() // where statements are not captured
+        blocks[ 4 ].statements == [ "x | y", "'a' | 'a'", "'b' | 'c'" ]
 
         and: 'The blocks should have the expected label and text'
         blocks[ 0 ].label == 'given'
@@ -282,8 +282,8 @@ class VividAstInspectorSpec extends Specification {
         and: 'The inspector should be able to provide the source code for each block'
         blocks[ 0 ].statements == [ 'x < y' ]
 
-        and: 'The where block is not captured'
-        blocks[ 1 ].statements.isEmpty()
+        and: 'The where block is captured'
+        blocks[ 1 ].statements == ['x   | y', '20  | 30', '100 | 2000']
 
         and: 'The cleanup block is captured'
         blocks[ 2 ].statements == [ 'x = null' ]


### PR DESCRIPTION
Skipping the `where` blocks altogether in the existing generators as you suggested did not fix the
test regressions because they were still used to build the data tables, instead I only
had to ignore the code statements from being iterated over.
But I believe these changes are as minimal and clean as possible. 