### PR TITLE
Fix #244 all info are grouped into 1st itertaion when no Unroll

### DIFF
--- a/src/main/groovy/com/athaydes/spockframework/report/extension/SpockReportsSpecificationExtension.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/extension/SpockReportsSpecificationExtension.groovy
@@ -51,7 +51,7 @@ class InfoContainer {
     private static String keyFor( String specName,
                                   FeatureInfo feature,
                                   IterationInfo iteration ) {
-        def index = Utils.isUnrolled( feature ) ? iteration.iterationIndex : -1
+        def index = Utils.isUnrolled( feature ) || ( iteration != null && iteration.estimatedNumIterations < 0 ) ? iteration.iterationIndex : -1
         "$specName${feature?.name}$index"
     }
 

--- a/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
+++ b/src/main/groovy/com/athaydes/spockframework/report/internal/HtmlReportCreator.groovy
@@ -277,10 +277,19 @@ class HtmlReportCreator extends AbstractHtmlCreator<SpecData>
                         failures ? 'failure' :
                                 ( !run || Utils.isSkipped( feature ) ) ? 'ignored' : ''
 
-                // collapse the information for all iterations
-                def extraInfo = run ? ( 1..run.failuresByIteration.size() ).collectMany {
-                    Utils.nextSpecExtraInfo( data, feature )
-                } : [ ]
+                def iterations = run ? run.copyFailuresByIteration().keySet().toList().sort { it.iterationIndex } : []
+                // Link each iteration's extra info to itself when there is no @Unroll
+                def extraInfo = []
+                def multipleIterations = iterations.size() > 1
+                if (run && multipleIterations) {
+                    extraInfo = iterations.collectMany {
+                        Utils.nextSpecExtraInfo(data, feature, it).collect { info -> "Iteration ${it.iterationIndex} extra info: $info" }
+                    }
+                } else if (run) {
+                    extraInfo = ( 1..run.failuresByIteration.size() ).collectMany {
+                        Utils.nextSpecExtraInfo( data, feature )
+                    }
+                }
 
                 Long time = run == null ? null : run.timeByIteration.values().sum()
 

--- a/src/test/resources/com/athaydes/spockframework/report/internal/SpecIncludingExtraInfoReport.html
+++ b/src/test/resources/com/athaydes/spockframework/report/internal/SpecIncludingExtraInfoReport.html
@@ -144,13 +144,13 @@
                 <div class='extra-info'>
                     <ul>
                         <li>
-                            <div>The current iteration is 0 (not-unrolled)</div>
+                            <div>Iteration 0 extra info: The current iteration is 0 (not-unrolled)</div>
                         </li>
                         <li>
-                            <div>The current iteration is 1 (not-unrolled)</div>
+                            <div>Iteration 1 extra info: The current iteration is 1 (not-unrolled)</div>
                         </li>
                         <li>
-                            <div>The current iteration is 2 (not-unrolled)</div>
+                            <div>Iteration 2 extra info: The current iteration is 2 (not-unrolled)</div>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Should check iteration.estimatedNumIterations to know if there is multiple iterations without Unroll, value is -1 under this case