### PR TITLE
Fix: Use Java toolchains for consistent JDK version management.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ group = 'com.athaydes'
 version = "2.6.0-groovy-5.0"
 description = 'This project is a global extension for Spock to create test (or, in Spock terms, Specifications) reports.'
 
-sourceCompatibility = '11'
-targetCompatibility = '11'
-
 def groovyVersion = '5.0.4'
 def spockVersion = '2.4-groovy-5.0'
 
@@ -67,6 +64,9 @@ jar {
 }
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION
This PR fixes the issue #266. The latest version `2.6.0-groovy-5.0` is not supported on Java versions less than 25, due to having been compiled on Java 25. The compiler ignored the `sourceCompatibility` and `targetCompatibility`, so a modern way to set this up was added.

`sourceCompatibility`/`targetCompatibility` are compiler flags — they affect which Java syntax is accepted but don't control which JDK executes the compilation. The Groovy compiler used by the Gradle build picked up the ambient JDK 25 regardless of those flags, producing class file version 69. A toolchain declaration tells Gradle to provision and use a specific JDK, making the bytecode version deterministic.